### PR TITLE
Support URL parameters to apply filters

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -544,6 +544,41 @@ header {
     display: none;
 }
 
+/* Share Filters Button */
+.share-filters-btn {
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid #007bff;
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 14px;
+    color: #007bff;
+    cursor: pointer;
+    transition: all 0.2s;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    backdrop-filter: blur(10px);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    white-space: nowrap;
+    font-weight: 500;
+    margin-left: 10px;
+}
+
+.share-filters-btn:hover {
+    background: #007bff;
+    color: white;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    transform: translateY(-1px);
+}
+
+.share-filters-btn.hidden {
+    display: none;
+}
+
+.share-icon {
+    margin-right: 4px;
+}
+
 /* Individual Clear Buttons */
 .clear-individual-btn {
     background: none;

--- a/docs/assets/js/filter-manager.js
+++ b/docs/assets/js/filter-manager.js
@@ -1,0 +1,422 @@
+class FilterManager {
+  constructor() {
+    this.activeFilters = {};
+    this.config = {
+      MAX_TERM_DISPLAY_LENGTH: 15,
+      DEBOUNCE_DELAY: 300
+    };
+    this.debouncedApplyFilters = this.debounce(this.applyFilters.bind(this), this.config.DEBOUNCE_DELAY);
+  }
+
+  init() {
+    this.initializeDropdowns();
+    this.initializeDatePicker();
+    this.initializeClearButtons();
+    this.initializeClickOutside();
+  }
+
+  initializeDropdowns() {
+    document.querySelectorAll('.filter-trigger').forEach(trigger => {
+      trigger.addEventListener('click', this.handleDropdownClick.bind(this));
+    });
+
+    document.querySelectorAll('.apply-filter-btn').forEach(btn => {
+      btn.addEventListener('click', this.handleApplyFilter.bind(this));
+    });
+
+    document.querySelectorAll('.clear-individual-btn').forEach(btn => {
+      btn.addEventListener('click', this.handleClearIndividual.bind(this));
+    });
+  }
+
+  handleDropdownClick(e) {
+    e.stopPropagation();
+    const dropdown = e.target.closest('.filter-dropdown');
+    const content = dropdown.querySelector('.filter-content');
+    const isOpen = content.classList.contains('show');
+
+    this.closeAllDropdowns();
+
+    if (!isOpen) {
+      content.classList.add('show');
+      e.target.classList.add('active');
+    }
+  }
+
+  handleApplyFilter(e) {
+    e.preventDefault();
+    const dropdown = e.target.closest('.filter-dropdown');
+    const filterType = dropdown.querySelector('.filter-trigger').dataset.filter;
+
+    this.processFilterValues(dropdown, filterType);
+    this.updateFilterDisplay(dropdown, filterType);
+    this.closeDropdown(dropdown);
+    this.updateMobileSummary();
+    this.syncWithMainForm();
+    this.debouncedApplyFilters();
+  }
+
+  processFilterValues(dropdown, filterType) {
+    const inputs = dropdown.querySelectorAll('input');
+
+    switch (filterType) {
+      case 'sales-date':
+        this.processSalesDateFilter(inputs[0]);
+        break;
+      case 'writ-amount':
+        this.processAmountFilter(inputs[0], inputs[1]);
+        break;
+      case 'terms':
+        this.processTermsFilter(inputs[0]);
+        break;
+      case 'zip':
+        this.processZipFilter(inputs[0]);
+        break;
+    }
+  }
+
+  processSalesDateFilter(dateInput) {
+    if (dateInput.value.trim()) {
+      this.activeFilters.salesDate = dateInput.value;
+    } else {
+      delete this.activeFilters.salesDate;
+    }
+  }
+
+  processAmountFilter(minInput, maxInput) {
+    const minValue = minInput.value.trim();
+    const maxValue = maxInput.value.trim();
+
+    if (minValue || maxValue) {
+      if (minValue) this.activeFilters.minAmount = minValue;
+      if (maxValue) this.activeFilters.maxAmount = maxValue;
+    } else {
+      delete this.activeFilters.minAmount;
+      delete this.activeFilters.maxAmount;
+    }
+  }
+
+  processTermsFilter(termsInput) {
+    if (termsInput.value.trim()) {
+      this.activeFilters.terms = termsInput.value;
+    } else {
+      delete this.activeFilters.terms;
+    }
+  }
+
+  processZipFilter(zipInput) {
+    if (zipInput.value.trim()) {
+      this.activeFilters.zip = zipInput.value;
+    } else {
+      delete this.activeFilters.zip;
+    }
+  }
+
+  updateFilterDisplay(dropdown, filterType) {
+    const trigger = dropdown.querySelector('.filter-trigger');
+    const valueSpan = trigger.querySelector('.filter-value');
+    const displayValue = this.getDisplayValue(filterType);
+
+    valueSpan.textContent = displayValue;
+
+    if (this.hasActiveFilter(filterType)) {
+      trigger.classList.add('active');
+    } else {
+      trigger.classList.remove('active');
+    }
+  }
+
+  getDisplayValue(filterType) {
+    switch (filterType) {
+      case 'sales-date':
+        return this.activeFilters.salesDate || 'All';
+      case 'writ-amount':
+        return this.getAmountDisplayValue();
+      case 'terms':
+        return this.getTermsDisplayValue();
+      case 'zip':
+        return this.activeFilters.zip || 'All';
+      default:
+        return 'All';
+    }
+  }
+
+  getAmountDisplayValue() {
+    const { minAmount, maxAmount } = this.activeFilters;
+
+    if (minAmount && maxAmount) {
+      return `$${minAmount} - $${maxAmount}`;
+    } else if (minAmount) {
+      return `> $${minAmount}`;
+    } else if (maxAmount) {
+      return `< $${maxAmount}`;
+    }
+    return 'All';
+  }
+
+  getTermsDisplayValue() {
+    if (!this.activeFilters.terms) return 'All';
+
+    const terms = this.activeFilters.terms;
+    return terms.length > this.config.MAX_TERM_DISPLAY_LENGTH
+      ? terms.substring(0, this.config.MAX_TERM_DISPLAY_LENGTH) + '...'
+      : terms;
+  }
+
+  hasActiveFilter(filterType) {
+    switch (filterType) {
+      case 'sales-date':
+        return !!this.activeFilters.salesDate;
+      case 'writ-amount':
+        return !!(this.activeFilters.minAmount || this.activeFilters.maxAmount);
+      case 'terms':
+        return !!this.activeFilters.terms;
+      case 'zip':
+        return !!this.activeFilters.zip;
+      default:
+        return false;
+    }
+  }
+
+  handleClearIndividual(e) {
+    e.preventDefault();
+    const filterType = e.target.dataset.filter;
+    const dropdown = e.target.closest('.filter-dropdown');
+
+    this.clearFilter(filterType, dropdown);
+    this.updateFilterDisplay(dropdown, filterType);
+    this.closeDropdown(dropdown);
+    this.updateMobileSummary();
+    this.syncWithMainForm();
+    this.debouncedApplyFilters();
+  }
+
+  clearFilter(filterType, dropdown) {
+    switch (filterType) {
+      case 'sales-date':
+        delete this.activeFilters.salesDate;
+        this.clearSalesDateInput(dropdown);
+        break;
+      case 'writ-amount':
+        delete this.activeFilters.minAmount;
+        delete this.activeFilters.maxAmount;
+        dropdown.querySelector('input[name="minAmount"]').value = '';
+        dropdown.querySelector('input[name="maxAmount"]').value = '';
+        break;
+      case 'terms':
+        delete this.activeFilters.terms;
+        dropdown.querySelector('input[name="terms"]').value = '';
+        break;
+      case 'zip':
+        delete this.activeFilters.zip;
+        dropdown.querySelector('input[name="zip"]').value = '';
+        break;
+    }
+  }
+
+  clearSalesDateInput(dropdown) {
+    const input = dropdown.querySelector('input[name="salesDate"]');
+    input.value = '';
+
+    if ($(input).data('daterangepicker')) {
+      $(input).data('daterangepicker').setStartDate(moment());
+      $(input).data('daterangepicker').setEndDate(moment());
+    }
+  }
+
+  initializeDatePicker() {
+    const salesDateInput = document.querySelector('#sales-date-dropdown input[name="salesDate"]');
+    if (!salesDateInput) return;
+
+    $(salesDateInput).daterangepicker({
+      autoUpdateInput: false,
+      locale: { cancelLabel: 'Clear' }
+    });
+
+    $(salesDateInput).on('apply.daterangepicker', (ev, picker) => {
+      const dateRange = `${picker.startDate.format('MM/DD/YYYY')} - ${picker.endDate.format('MM/DD/YYYY')}`;
+      $(salesDateInput).val(dateRange);
+
+      this.activeFilters.salesDate = dateRange;
+      this.updateSalesDateDisplay(dateRange);
+      this.updateMobileSummary();
+      this.syncWithMainForm();
+      this.debouncedApplyFilters();
+    });
+
+    $(salesDateInput).on('cancel.daterangepicker', () => {
+      $(salesDateInput).val('');
+      delete this.activeFilters.salesDate;
+
+      this.updateSalesDateDisplay('All');
+      this.updateMobileSummary();
+      this.syncWithMainForm();
+      this.debouncedApplyFilters();
+    });
+  }
+
+  updateSalesDateDisplay(value) {
+    const trigger = document.querySelector('#sales-date-dropdown .filter-trigger');
+    const valueSpan = trigger.querySelector('.filter-value');
+    valueSpan.textContent = value;
+
+    if (value === 'All') {
+      trigger.classList.remove('active');
+    } else {
+      trigger.classList.add('active');
+    }
+  }
+
+  initializeClearButtons() {
+    const clearBtn = document.getElementById('clear-filters-btn');
+    const clearMobileBtn = document.getElementById('clear-filters-mobile-btn');
+
+    if (clearBtn) {
+      clearBtn.addEventListener('click', () => this.clearAllFilters());
+    }
+
+    if (clearMobileBtn) {
+      clearMobileBtn.addEventListener('click', () => this.clearAllFilters());
+    }
+  }
+
+  initializeClickOutside() {
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.filter-dropdown')) {
+        this.closeAllDropdowns();
+      }
+    });
+  }
+
+  closeAllDropdowns() {
+    document.querySelectorAll('.filter-content').forEach(c => c.classList.remove('show'));
+    document.querySelectorAll('.filter-trigger').forEach(t => t.classList.remove('active'));
+  }
+
+  closeDropdown(dropdown) {
+    dropdown.querySelector('.filter-content').classList.remove('show');
+    dropdown.querySelector('.filter-trigger').classList.remove('active');
+  }
+
+  clearAllFilters() {
+    this.activeFilters = {};
+    this.resetAllDisplays();
+    this.resetAllInputs();
+    this.updateMobileSummary();
+    this.syncWithMainForm();
+    this.debouncedApplyFilters();
+  }
+
+  resetAllDisplays() {
+    document.querySelectorAll('.filter-trigger').forEach(trigger => {
+      const valueSpan = trigger.querySelector('.filter-value');
+      valueSpan.textContent = 'All';
+      trigger.classList.remove('active');
+    });
+  }
+
+  resetAllInputs() {
+    document.querySelectorAll('.filter-panel input').forEach(input => {
+      input.value = '';
+    });
+
+    const salesDateInput = document.querySelector('#sales-date-dropdown input[name="salesDate"]');
+    if (salesDateInput && $(salesDateInput).data('daterangepicker')) {
+      $(salesDateInput).data('daterangepicker').setStartDate(moment());
+      $(salesDateInput).data('daterangepicker').setEndDate(moment());
+      $(salesDateInput).val('');
+    }
+  }
+
+  updateMobileSummary() {
+    const activeCount = Object.keys(this.activeFilters).length;
+    const summaryText = document.querySelector('.filter-summary-text');
+
+    if (summaryText) {
+      summaryText.textContent = `Filters: ${activeCount} applied`;
+    }
+
+    const clearBtn = document.getElementById('clear-filters-btn');
+    if (clearBtn) {
+      clearBtn.classList.toggle('hidden', activeCount === 0);
+    }
+  }
+
+  syncWithMainForm() {
+    const form = document.getElementById('filters-form');
+    if (!form) return;
+
+    form.reset();
+
+    Object.keys(this.activeFilters).forEach(key => {
+      const input = form.querySelector(`[name="${key}"]`);
+      if (input) {
+        input.value = this.activeFilters[key];
+      }
+    });
+  }
+
+  updateDesktopFilterDisplays() {
+    const filterTypes = ['sales-date', 'writ-amount', 'terms', 'zip'];
+
+    filterTypes.forEach(filterType => {
+      const dropdown = document.querySelector(`#${filterType.replace('-', '-')}-dropdown`);
+      if (dropdown) {
+        this.updateFilterDisplay(dropdown, filterType);
+      }
+    });
+
+    this.updateMobileSummary();
+  }
+
+  applyFilters() {
+    const filterParams = this.getFilterParams();
+
+    if (window.App && App.searchData) {
+      const result = App.searchData(filterParams);
+      document.getElementById('property-count-tag').textContent = result + ' Properties';
+    }
+  }
+
+  getFilterParams() {
+    return {
+      salesDate: this.activeFilters.salesDate || '',
+      maxAmount: this.activeFilters.maxAmount || '',
+      minAmount: this.activeFilters.minAmount || '',
+      terms: this.activeFilters.terms || '',
+      zip: this.activeFilters.zip || ''
+    };
+  }
+
+  debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout);
+        func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+
+  // Public method to sync mobile modal changes
+  syncFromMobileModal() {
+    const form = document.getElementById('filters-form');
+    if (!form) return;
+
+    const formData = new FormData(form);
+    this.activeFilters = {};
+
+    if (formData.get('salesDate')) this.activeFilters.salesDate = formData.get('salesDate');
+    if (formData.get('minAmount')) this.activeFilters.minAmount = formData.get('minAmount');
+    if (formData.get('maxAmount')) this.activeFilters.maxAmount = formData.get('maxAmount');
+    if (formData.get('terms')) this.activeFilters.terms = formData.get('terms');
+    if (formData.get('zip')) this.activeFilters.zip = formData.get('zip');
+
+    this.updateDesktopFilterDisplays();
+  }
+}
+
+// Export for use in main script
+window.FilterManager = FilterManager;

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Map of Orleans Parish Sheriff's Sale properties in New Orleans, LA. View foreclosures, filter by date, amount, terms, and zip code. Get background and contextual information about the property such as tax liens, ownership history, and more." />
+
   <title>Sheriff's Sale Database</title>
   <link rel="stylesheet" href="./assets/vendors/leaflet/leaflet.css" />
   <link rel="stylesheet" href="./assets/vendors/daterangepicker/daterangepicker.css" />
@@ -104,7 +105,7 @@
               </div>
             </div>
           </div>
-          <button class="btn btn-primary btn-sm mt-2 apply-filter-btn">Apply</button>
+          <button class="btn btn-primary btn-sm mt-2 apply-filter-btn" id="apply-writ-amount-filter">Apply</button>
         </div>
       </div>
     </div>
@@ -122,7 +123,7 @@
             <button class="clear-individual-btn" data-filter="terms">Clear</button>
           </div>
           <input type="text" class="form-control" name="terms" placeholder="Enter text..." />
-          <button class="btn btn-primary btn-sm mt-2 apply-filter-btn">Apply</button>
+          <button class="btn btn-primary btn-sm mt-2 apply-filter-btn" id="apply-terms-filter">Apply</button>
         </div>
       </div>
     </div>
@@ -140,7 +141,7 @@
             <button class="clear-individual-btn" data-filter="zip">Clear</button>
           </div>
           <input type="number" class="form-control" name="zip" placeholder="Enter zip code..." />
-          <button class="btn btn-primary btn-sm mt-2 apply-filter-btn">Apply</button>
+          <button class="btn btn-primary btn-sm mt-2 apply-filter-btn" id="apply-zip-filter">Apply</button>
         </div>
       </div>
     </div>
@@ -338,6 +339,7 @@
   <script src="./assets/vendors/leaflet/leaflet.js"></script>
   <script src="./assets/vendors/lodash/lodash.min.js"></script>
   <script src="./assets/js/filters.js"></script>
+  <script src="./assets/js/filter-manager.js"></script>
   <script src="./assets/js/app.js"></script>
 
   <script>
@@ -350,311 +352,10 @@
       },
     };
 
-    // Filter management
-    let activeFilters = {};
-    
-    function initializeFilters() {
-      // Handle dropdown triggers
-      document.querySelectorAll('.filter-trigger').forEach(trigger => {
-        trigger.addEventListener('click', function(e) {
-          e.stopPropagation();
-          const dropdown = this.closest('.filter-dropdown');
-          const content = dropdown.querySelector('.filter-content');
-          const isOpen = content.classList.contains('show');
-          
-          // Close all other dropdowns
-          document.querySelectorAll('.filter-content').forEach(c => c.classList.remove('show'));
-          document.querySelectorAll('.filter-trigger').forEach(t => t.classList.remove('active'));
-          
-          // Toggle current dropdown
-          if (!isOpen) {
-            content.classList.add('show');
-            this.classList.add('active');
-          }
-        });
-      });
-      
-      // Handle apply buttons
-      document.querySelectorAll('.apply-filter-btn').forEach(btn => {
-        btn.addEventListener('click', function(e) {
-          e.preventDefault();
-          const dropdown = this.closest('.filter-dropdown');
-          const filterType = dropdown.querySelector('.filter-trigger').dataset.filter;
-          
-          // Get values from inputs
-          const inputs = dropdown.querySelectorAll('input');
-          let hasValue = false;
-          let displayValue = 'All';
-          
-          if (filterType === 'sales-date') {
-            const dateInput = inputs[0];
-            if (dateInput.value.trim()) {
-              activeFilters.salesDate = dateInput.value;
-              displayValue = dateInput.value;
-              hasValue = true;
-            } else {
-              delete activeFilters.salesDate;
-            }
-          } else if (filterType === 'writ-amount') {
-            const minInput = inputs[0];
-            const maxInput = inputs[1];
-            if (minInput.value.trim() || maxInput.value.trim()) {
-              activeFilters.minAmount = minInput.value;
-              activeFilters.maxAmount = maxInput.value;
-              if (minInput.value && maxInput.value) {
-                displayValue = `$${minInput.value} - $${maxInput.value}`;
-              } else if (minInput.value) {
-                displayValue = `> $${minInput.value}`;
-              } else if (maxInput.value) {
-                displayValue = `< $${maxInput.value}`;
-              }
-              hasValue = true;
-            } else {
-              delete activeFilters.minAmount;
-              delete activeFilters.maxAmount;
-            }
-          } else if (filterType === 'terms') {
-            const termsInput = inputs[0];
-            if (termsInput.value.trim()) {
-              activeFilters.terms = termsInput.value;
-              displayValue = termsInput.value.length > 15 ? termsInput.value.substring(0, 15) + '...' : termsInput.value;
-              hasValue = true;
-            } else {
-              delete activeFilters.terms;
-            }
-          } else if (filterType === 'zip') {
-            const zipInput = inputs[0];
-            if (zipInput.value.trim()) {
-              activeFilters.zip = zipInput.value;
-              displayValue = zipInput.value;
-              hasValue = true;
-            } else {
-              delete activeFilters.zip;
-            }
-          }
-          
-          // Update display
-          const trigger = dropdown.querySelector('.filter-trigger');
-          const valueSpan = trigger.querySelector('.filter-value');
-          valueSpan.textContent = displayValue;
-          
-          if (hasValue) {
-            trigger.classList.add('active');
-          } else {
-            trigger.classList.remove('active');
-          }
-          
-          // Close dropdown
-          dropdown.querySelector('.filter-content').classList.remove('show');
-          trigger.classList.remove('active');
-          
-          // Update mobile summary
-          updateMobileSummary();
-          
-          // Sync with main form and apply filters
-          syncWithMainForm();
-          applyFilters();
-        });
-      });
-      
-      // Handle individual clear buttons
-      document.querySelectorAll('.clear-individual-btn').forEach(btn => {
-        btn.addEventListener('click', function(e) {
-          e.preventDefault();
-          const filterType = this.dataset.filter;
-          const dropdown = this.closest('.filter-dropdown');
-          
-          // Clear the specific filter
-          if (filterType === 'sales-date') {
-            delete activeFilters.salesDate;
-            const input = dropdown.querySelector('input[name="salesDate"]');
-            input.value = '';
-            // Reset date picker if it exists
-            if ($(input).data('daterangepicker')) {
-              $(input).data('daterangepicker').setStartDate(moment());
-              $(input).data('daterangepicker').setEndDate(moment());
-            }
-          } else if (filterType === 'writ-amount') {
-            delete activeFilters.minAmount;
-            delete activeFilters.maxAmount;
-            dropdown.querySelector('input[name="minAmount"]').value = '';
-            dropdown.querySelector('input[name="maxAmount"]').value = '';
-          } else if (filterType === 'terms') {
-            delete activeFilters.terms;
-            dropdown.querySelector('input[name="terms"]').value = '';
-          } else if (filterType === 'zip') {
-            delete activeFilters.zip;
-            dropdown.querySelector('input[name="zip"]').value = '';
-          }
-          
-          // Update display
-          const trigger = dropdown.querySelector('.filter-trigger');
-          const valueSpan = trigger.querySelector('.filter-value');
-          valueSpan.textContent = 'All';
-          trigger.classList.remove('active');
-          
-          // Close dropdown
-          dropdown.querySelector('.filter-content').classList.remove('show');
-          
-          // Update mobile summary and sync
-          updateMobileSummary();
-          syncWithMainForm();
-          applyFilters();
-        });
-      });
-      
-      // Close dropdowns when clicking outside
-      document.addEventListener('click', function(e) {
-        if (!e.target.closest('.filter-dropdown')) {
-          document.querySelectorAll('.filter-content').forEach(c => c.classList.remove('show'));
-          document.querySelectorAll('.filter-trigger').forEach(t => t.classList.remove('active'));
-        }
-      });
-      
-      // Initialize date picker for sales date
-      const salesDateInput = document.querySelector('#sales-date-dropdown input[name="salesDate"]');
-      if (salesDateInput) {
-        $(salesDateInput).daterangepicker({
-          autoUpdateInput: false,
-          locale: {
-            cancelLabel: 'Clear'
-          }
-        });
-        
-        $(salesDateInput).on('apply.daterangepicker', function(ev, picker) {
-          const dateRange = picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY');
-          $(this).val(dateRange);
-          
-          // Immediately update the filter display
-          activeFilters.salesDate = dateRange;
-          const trigger = document.querySelector('#sales-date-dropdown .filter-trigger');
-          const valueSpan = trigger.querySelector('.filter-value');
-          valueSpan.textContent = dateRange;
-          trigger.classList.add('active');
-          
-          // Update mobile summary and apply filters
-          updateMobileSummary();
-          syncWithMainForm();
-          applyFilters();
-        });
-        
-        $(salesDateInput).on('cancel.daterangepicker', function(ev, picker) {
-          $(this).val('');
-          delete activeFilters.salesDate;
-          
-          const trigger = document.querySelector('#sales-date-dropdown .filter-trigger');
-          const valueSpan = trigger.querySelector('.filter-value');
-          valueSpan.textContent = 'All';
-          trigger.classList.remove('active');
-          
-          updateMobileSummary();
-          syncWithMainForm();
-          applyFilters();
-        });
-      }
-    }
-    
-    function updateMobileSummary() {
-      const activeCount = Object.keys(activeFilters).length;
-      const summaryText = document.querySelector('.filter-summary-text');
-      if (summaryText) {
-        summaryText.textContent = `Filters: ${activeCount} applied`;
-      }
-      
-      // Show/hide clear button based on active filters
-      const clearBtn = document.getElementById('clear-filters-btn');
-      if (clearBtn) {
-        if (activeCount > 0) {
-          clearBtn.classList.remove('hidden');
-        } else {
-          clearBtn.classList.add('hidden');
-        }
-      }
-    }
-    
-    function syncWithMainForm() {
-      const form = document.getElementById('filters-form');
-      if (!form) return;
-      
-      // Clear form
-      form.reset();
-      
-      // Set values from activeFilters
-      Object.keys(activeFilters).forEach(key => {
-        const input = form.querySelector(`[name="${key}"]`);
-        if (input) {
-          input.value = activeFilters[key];
-        }
-      });
-    }
-    
-    function applyFilters() {
-      // Trigger the existing filter logic using App.searchData
-      const filters = {
-        salesDate: activeFilters.salesDate || '',
-        maxAmount: activeFilters.maxAmount || '',
-        minAmount: activeFilters.minAmount || '',
-        terms: activeFilters.terms || '',
-        zip: activeFilters.zip || ''
-      };
-      
-      // Apply filters using the existing App system
-      if (window.App && App.searchData) {
-        const result = App.searchData(filters);
-        document.getElementById('property-count-tag').textContent = result + ' Properties';
-      }
-    }
-
-    function initializeClearFilters() {
-      // Desktop clear button
-      const clearBtn = document.getElementById('clear-filters-btn');
-      if (clearBtn) {
-        clearBtn.addEventListener('click', function() {
-          clearAllFilters();
-        });
-      }
-      
-      // Mobile clear button
-      const clearMobileBtn = document.getElementById('clear-filters-mobile-btn');
-      if (clearMobileBtn) {
-        clearMobileBtn.addEventListener('click', function() {
-          clearAllFilters();
-        });
-      }
-    }
-    
-    function clearAllFilters() {
-      // Reset activeFilters object
-      activeFilters = {};
-      
-      // Reset all desktop filter displays
-      document.querySelectorAll('.filter-trigger').forEach(trigger => {
-        const valueSpan = trigger.querySelector('.filter-value');
-        valueSpan.textContent = 'All';
-        trigger.classList.remove('active');
-      });
-      
-      // Reset all filter inputs
-      document.querySelectorAll('.filter-panel input').forEach(input => {
-        input.value = '';
-      });
-      
-      // Reset date picker
-      const salesDateInput = document.querySelector('#sales-date-dropdown input[name="salesDate"]');
-      if (salesDateInput && $(salesDateInput).data('daterangepicker')) {
-        $(salesDateInput).data('daterangepicker').setStartDate(moment());
-        $(salesDateInput).data('daterangepicker').setEndDate(moment());
-        $(salesDateInput).val('');
-      }
-      
-      // Update mobile summary and sync
-      updateMobileSummary();
-      syncWithMainForm();
-      applyFilters();
-    }
+    // Initialize filter manager
+    let filterManager;
 
     $(function() {
-
       const { createClient } = supabase;
       const _supabase = createClient('https://yzrchvjkugjhutloijih.supabase.co', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inl6cmNodmprdWdqaHV0bG9pamloIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkyNjU1NjUsImV4cCI6MjA2NDg0MTU2NX0.3xfi0GZUfEfBV4bsWhJNOr1TJqdaLbA_sLl6WfALLK0');
 
@@ -678,93 +379,16 @@
           App.corruptData.map((item) => {return item["Address/Description"]}).join("\n")
         );
 
-        // Initialize the new filter interface
-        initializeFilters();
-
-        // Add clear filters functionality
-        initializeClearFilters();
+        // Initialize the filter manager
+        filterManager = new FilterManager();
+        filterManager.init();
 
         // Sync mobile modal with desktop filters
         $('#filters-modal').on('hidden.bs.modal', function() {
-          // When mobile modal closes, sync any changes back to desktop filters
-          const form = document.getElementById('filters-form');
-          if (form) {
-            const formData = new FormData(form);
-            
-            // Update activeFilters from modal form
-            activeFilters = {};
-            
-            if (formData.get('salesDate')) activeFilters.salesDate = formData.get('salesDate');
-            if (formData.get('minAmount')) activeFilters.minAmount = formData.get('minAmount');
-            if (formData.get('maxAmount')) activeFilters.maxAmount = formData.get('maxAmount');
-            if (formData.get('terms')) activeFilters.terms = formData.get('terms');
-            if (formData.get('zip')) activeFilters.zip = formData.get('zip');
-            
-            // Update desktop filter displays
-            updateDesktopFilterDisplays();
-            updateMobileSummary();
-          }
+          filterManager.syncFromMobileModal();
         });
       });
     });
-
-    function updateDesktopFilterDisplays() {
-      // Sales Date
-      const salesDateTrigger = document.querySelector('#sales-date-dropdown .filter-trigger');
-      const salesDateValue = salesDateTrigger.querySelector('.filter-value');
-      if (activeFilters.salesDate) {
-        salesDateValue.textContent = activeFilters.salesDate;
-        salesDateTrigger.classList.add('active');
-      } else {
-        salesDateValue.textContent = 'All';
-        salesDateTrigger.classList.remove('active');
-      }
-      
-      // Writ Amount
-      const writAmountTrigger = document.querySelector('#writ-amount-dropdown .filter-trigger');
-      const writAmountValue = writAmountTrigger.querySelector('.filter-value');
-      if (activeFilters.minAmount || activeFilters.maxAmount) {
-        let displayValue = '';
-        if (activeFilters.minAmount && activeFilters.maxAmount) {
-          displayValue = `$${activeFilters.minAmount} - $${activeFilters.maxAmount}`;
-        } else if (activeFilters.minAmount) {
-          displayValue = `> $${activeFilters.minAmount}`;
-        } else if (activeFilters.maxAmount) {
-          displayValue = `< $${activeFilters.maxAmount}`;
-        }
-        writAmountValue.textContent = displayValue;
-        writAmountTrigger.classList.add('active');
-      } else {
-        writAmountValue.textContent = 'All';
-        writAmountTrigger.classList.remove('active');
-      }
-      
-      // Terms
-      const termsTrigger = document.querySelector('#terms-dropdown .filter-trigger');
-      const termsValue = termsTrigger.querySelector('.filter-value');
-      if (activeFilters.terms) {
-        const displayValue = activeFilters.terms.length > 15 ? activeFilters.terms.substring(0, 15) + '...' : activeFilters.terms;
-        termsValue.textContent = displayValue;
-        termsTrigger.classList.add('active');
-      } else {
-        termsValue.textContent = 'All';
-        termsTrigger.classList.remove('active');
-      }
-      
-      // Zip
-      const zipTrigger = document.querySelector('#zip-dropdown .filter-trigger');
-      const zipValue = zipTrigger.querySelector('.filter-value');
-      if (activeFilters.zip) {
-        zipValue.textContent = activeFilters.zip;
-        zipTrigger.classList.add('active');
-      } else {
-        zipValue.textContent = 'All';
-        zipTrigger.classList.remove('active');
-      }
-      
-      // Update clear button visibility
-      updateMobileSummary();
-    }
 
     // Hide navbar collapse after clicking any nav-link (mobile)
     $(document).on('click', '.navbar-collapse .nav-link', function(){

--- a/docs/index.html
+++ b/docs/index.html
@@ -157,6 +157,12 @@
       Clear Filters
     </button>
 
+    <!-- Share Filters button -->
+    <button class="share-filters-btn hidden" id="share-filters-btn" title="Copy shareable link">
+      <span class="share-icon">🔗</span>
+      Share
+    </button>
+
     <!-- Set Email Alert button -->
     <button class="email-alert-btn" data-bs-toggle="modal" data-bs-target="#email-alert-modal">
       <span class="bell-icon">🔔</span>

--- a/test_url_params.html
+++ b/test_url_params.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>🔗 URL Parameters Test - NOSS Filter Manager</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .test-link {
+            display: inline-block;
+            background: #007bff;
+            color: white;
+            padding: 10px 20px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 10px 10px 10px 0;
+            transition: background 0.2s;
+        }
+        .test-link:hover {
+            background: #0056b3;
+            color: white;
+            text-decoration: none;
+        }
+        .code {
+            background: #f8f9fa;
+            padding: 15px;
+            border-radius: 5px;
+            border-left: 4px solid #007bff;
+            margin: 10px 0;
+            font-family: monospace;
+            overflow-x: auto;
+        }
+        .feature {
+            background: #f0f8ff;
+            padding: 15px;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>🔗 URL Parameters Test for NOSS Filter Manager</h1>
+    
+    <p>The filter manager now supports URL parameters for sharing and bookmarking specific filter combinations. Test the examples below:</p>
+
+    <div class="feature">
+        <h3>✨ New Features Added:</h3>
+        <ul>
+            <li><strong>URL Parameter Support</strong> - Filters are saved in the URL for sharing</li>
+            <li><strong>Browser Navigation</strong> - Back/forward buttons work with filter states</li>
+            <li><strong>Share Button</strong> - Copy shareable links with current filters</li>
+            <li><strong>Deep Linking</strong> - Direct access to filtered views</li>
+            <li><strong>Persistent State</strong> - Filters persist across page reloads</li>
+        </ul>
+    </div>
+
+    <h2>Test URLs</h2>
+    
+    <h3>Sales Date Filter</h3>
+    <a href="docs/index.html?salesDate=01/01/2024%20-%2001/31/2024" class="test-link">
+        January 2024 Sales
+    </a>
+    <div class="code">
+        docs/index.html?salesDate=01/01/2024%20-%2001/31/2024
+    </div>
+
+    <h3>Amount Range Filter</h3>
+    <a href="docs/index.html?minAmount=50000&maxAmount=150000" class="test-link">
+        $50K - $150K Range
+    </a>
+    <div class="code">
+        docs/index.html?minAmount=50000&maxAmount=150000
+    </div>
+
+    <h3>Zip Code Filter</h3>
+    <a href="docs/index.html?zip=70112" class="test-link">
+        Zip Code 70112
+    </a>
+    <div class="code">
+        docs/index.html?zip=70112
+    </div>
+
+    <h3>Terms Filter</h3>
+    <a href="docs/index.html?terms=cash" class="test-link">
+        Cash Terms Only
+    </a>
+    <div class="code">
+        docs/index.html?terms=cash
+    </div>
+
+    <h3>Combined Filters</h3>
+    <a href="docs/index.html?salesDate=01/01/2024%20-%2003/31/2024&minAmount=75000&zip=70112&terms=cash" class="test-link">
+        Q1 2024, $75K+, Zip 70112, Cash
+    </a>
+    <div class="code">
+        docs/index.html?salesDate=01/01/2024%20-%2003/31/2024&minAmount=75000&zip=70112&terms=cash
+    </div>
+
+    <h2>How to Use</h2>
+    <div class="feature">
+        <h3>For Users:</h3>
+        <ol>
+            <li>Apply filters on the main map page</li>
+            <li>Click the <strong>🔗 Share</strong> button to copy the current URL</li>
+            <li>Share the URL with others or bookmark it</li>
+            <li>The URL will automatically restore the same filters when visited</li>
+        </ol>
+
+        <h3>For Developers:</h3>
+        <p>Supported URL parameters:</p>
+        <ul>
+            <li><code>salesDate</code> - Date range in "MM/DD/YYYY - MM/DD/YYYY" format</li>
+            <li><code>minAmount</code> - Minimum writ amount (number)</li>
+            <li><code>maxAmount</code> - Maximum writ amount (number)</li>
+            <li><code>terms</code> - Terms and conditions text search</li>
+            <li><code>zip</code> - ZIP code filter (5 digits)</li>
+        </ul>
+    </div>
+
+    <h2>Implementation Details</h2>
+    <div class="feature">
+        <h3>Technical Features:</h3>
+        <ul>
+            <li><strong>Debounced URL Updates</strong> - Prevents excessive history entries</li>
+            <li><strong>History API</strong> - Uses pushState for seamless navigation</li>
+            <li><strong>URL Encoding</strong> - Properly handles special characters</li>
+            <li><strong>Fallback Support</strong> - Works with older browsers using execCommand</li>
+            <li><strong>State Synchronization</strong> - Keeps all UI elements in sync</li>
+        </ul>
+    </div>
+
+    <p><a href="docs/index.html" class="test-link">← Back to Main Map</a></p>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds support for applying filters by URL parameters. The existing buttons to add and construct filters is still supported, but by capturing the filters in URL parameters we can share a specific filter setting. This then allows for created pages to show listings for a particular zip code or date. Also, a "share" button is included to copy the URL with params to the clipboard.